### PR TITLE
fix: default account creation on sign up

### DIFF
--- a/lil_bank/accounts/models.py
+++ b/lil_bank/accounts/models.py
@@ -23,7 +23,7 @@ class Customer(models.Model):
 
 class Account(models.Model):
     no: models.AutoField = models.AutoField(primary_key=True)
-    type: models.CharField = models.CharField(max_length=32, default="checking")
+    type: models.CharField = models.CharField(max_length=32, default="Checking")
     owner: models.ForeignKey = models.ForeignKey(
         Customer,
         on_delete=models.CASCADE,

--- a/lil_bank/accounts/views.py
+++ b/lil_bank/accounts/views.py
@@ -83,15 +83,9 @@ class SignUpView(TemplateView):
                 phone=form.cleaned_data['phone'],
             )
 
-            # Create a new account.
-            account = Account.objects.create(
-                no=customer.id,
-                owner=customer,
-            )
             # Write to the database.
             user.save()
             customer.save()
-            account.save()
 
             # Redirect to the login page.
             # The logger is used here.


### PR DESCRIPTION
There was an error where the new account number is the same as the cutomer id which is a bug.

We essentially don't need an account created at sign up, the customer can easily open an account at his will.