### PR TITLE
fix: sign up test and phone validation

### DIFF
--- a/lil_bank/accounts/forms.py
+++ b/lil_bank/accounts/forms.py
@@ -42,8 +42,9 @@ class SignUpForm(forms.Form):
     
     def clean_phone(self):
         phone = self.cleaned_data['phone']
-        if not re.match(r'^[0-9]+$', phone) and len(phone) != 10:
-            raise forms.ValidationError("Phone number must contain only numbers and be 10 digits long.")
+        # Validation for 10 digit phone number
+        if not re.match(r'^\d{10}$', phone):
+            raise forms.ValidationError("Phone number must contain only numbers be 10 digits.")
         return phone
     
     def clean_password2(self):

--- a/lil_bank/accounts/tests/test_auth.py
+++ b/lil_bank/accounts/tests/test_auth.py
@@ -13,7 +13,7 @@ class TestAuthentication(TestCase):
             'username': 'test_user_1',
             'email': 'test@user.com',
             'address': '#1 Test, User Nagar',
-            'phone': '19199191',
+            'phone': '1234567890',
             'password1': 'test_user_password',
             'password2': 'test_user_password',
         }


### PR DESCRIPTION
Aritra and I discovered that the phone number validation was not validating for the length of the phone number. While fixing that, we discovered that "r'^\d{10}$'" was failing the test because the test was written incorrectly. We fixed the test and the validation.